### PR TITLE
stop aco.select form calling itself

### DIFF
--- a/jquery.tag-editor.js
+++ b/jquery.tag-editor.js
@@ -166,7 +166,7 @@
                         input = $(this).html('<input type="text" maxlength="'+o.maxLength+'" value="'+tag+'">').addClass('active').find('input');
                         input.data('old_tag', tag).focus().autoGrowInput().trigger('autogrow').caret(caret_pos);
                     if (o.autocomplete) {
-                        var aco = o.autocomplete;
+                        var aco = $.extend({},o.autocomplete);
                         // extend user provided autocomplete select method
                         var ac_select = 'select'  in aco ? o.autocomplete.select : '';
                         aco.select = function(){ if (ac_select) ac_select(); setTimeout(function(){ $('.active', ed).find('input').trigger('autogrow'); }, 20); };


### PR DESCRIPTION
each select event calls the handler created for the previous input select, creating an exponentially growing number of select event handlers firing each time.

to prevent this, don't use the same autocomplete options object each time. make a copy instead. 

made a demo so you can observe the growing number of select handler calls: http://rawgit.com/kemmis/jQuery-tagEditor/select-bug/demo.html
