### PR TITLE
Fix syntax error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     }],
     "ignore": [
         "bower.json",
-        "demo.html"
+        "demo.html",
         "readme.md",
         "tag-editor.jquery.json"
     ]


### PR DESCRIPTION
bower.json has a syntax error, so i get the following error while using the library with bower :

``` bash
$ bower register jQuery-tagEditor git@github.com:Pixabay/jQuery-tagEditor.git
bower                          convert Converted git@github.com:Pixabay/jQuery-tagEditor.git to git://github.com/Pixabay/jQuery-tagEditor.git
bower jQuery-tagEditor#*       resolve git://github.com/Pixabay/jQuery-tagEditor.git#*
bower jQuery-tagEditor#*      download https://github.com/Pixabay/jQuery-tagEditor/archive/1.0.9.tar.gz
bower jQuery-tagEditor#*       extract archive.tar.gz
bower jQuery-tagEditor#*    EMALFORMED Failed to read /tmp/romainalm/bower/jQuery-tagEditor-27071-p9cqQe/bower.json

Additional error details:
Unexpected string
```
