### PR TITLE
Update jquery.tag-editor.js

### DIFF
--- a/jquery.tag-editor.js
+++ b/jquery.tag-editor.js
@@ -226,7 +226,7 @@
                 else if (tag.indexOf(o.delimiter[0])>=0) { split_cleanup(input); return; }
                 else if (tag != old_tag) {
                     if (o.forceLowercase) tag = tag.toLowerCase();
-                    cb_val = o.beforeTagSave(el, ed, tag_list, old_tag, tag);
+                    var cb_val = o.beforeTagSave(el, ed, tag_list, old_tag, tag);
                     tag = cb_val || tag;
                     if (cb_val === false) {
                         if (old_tag) {


### PR DESCRIPTION
Fixing error: "Uncaught ReferenceError: cb_val is not defined" that gets fired when users hit Enter after entering a new tag
Browser: Chrome.
OS: OSX