### PR TITLE
Fixed: when maxTags limit is reached, trigger input blur

### DIFF
--- a/jquery.tag-editor.js
+++ b/jquery.tag-editor.js
@@ -313,6 +313,10 @@
                 // enter key
                 else if (e.which == 13) {
                     ed.trigger('click', [$t.closest('li').next('li').find('.tag-editor-tag')]);
+
+                    // If the maxTags limit is reached, trigger blur
+                    if (o.maxTags && ed.data('tags').length >= o.maxTags) { ed.find('input').blur(); }
+
                     return false;
                 }
                 // pos1


### PR DESCRIPTION
Fixes #69 
Check if the maxTags limit is reached on Enter key press, if so - trigger input blur - so the user can not add more tags.