### PR TITLE
Modify callbacks after tagEditor was initialized

### DIFF
--- a/jquery.tag-editor.js
+++ b/jquery.tag-editor.js
@@ -45,6 +45,12 @@
                     if (!blur) ed.click();
                 } else if (options == 'destroy') {
                     el.removeClass('tag-editor-hidden-src').removeData('options').off('focus.tag-editor').next('.tag-editor').remove();
+                } else if (options == 'onChange') {
+                    o.onChange = val;
+                } else if (options == 'beforeTagSave') {
+                    o.beforeTagSave = val;
+                } else if (options == 'beforeTagDelete') {
+                    o.beforeTagDelete = val;
                 }
             });
             return options == 'getTags' ? response : this;


### PR DESCRIPTION
I need a way to modify the callbacks *after* the tagEditor was initialized. Therefore I added three methods 

- `onChange(callback)`
- `beforeTagSave(callback)`
- `beforeTagDelete(callback)`
