### PR TITLE
When using jQuery-UI autocomplete, honour _renderItem extension point

### DIFF
--- a/jquery.tag-editor.js
+++ b/jquery.tag-editor.js
@@ -181,6 +181,9 @@
                             ed.trigger('click', [$('.active', ed).find('input').closest('li').next('li').find('.tag-editor-tag')]);
                         }, 20); };
                         input.autocomplete(aco);
+                        if (aco._renderItem) {
+                            input.autocomplete('instance')._renderItem = aco._renderItem;
+                        }
                     }
                 }
                 return false;


### PR DESCRIPTION
The _renderItem extension in autocomplete is called if it’s been defined.